### PR TITLE
Decode GeoJSON LineString

### DIFF
--- a/linestring.go
+++ b/linestring.go
@@ -2,6 +2,9 @@ package geom
 
 import (
 	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
 	"strconv"
 )
 
@@ -10,6 +13,11 @@ import (
 type LineString struct {
 	Coordinates []float64
 	Extra       int
+}
+
+type geoJSONLineString struct {
+	Type        string      `json:"type"`
+	Coordinates [][]float64 `json:"coordinates"`
 }
 
 // MarshalJSON returns the GeoJSON representation of the line.
@@ -34,4 +42,39 @@ func (line *LineString) MarshalJSON() ([]byte, error) {
 
 	buffer.WriteString(`]}`)
 	return buffer.Bytes(), nil
+}
+
+// UnmarshalJSON creates a linestring from GeoJSON.
+func (line *LineString) UnmarshalJSON(data []byte) error {
+	geoJSON := geoJSONLineString{}
+	if err := json.Unmarshal(data, &geoJSON); err != nil {
+		return err
+	}
+	if geoJSON.Type != "LineString" {
+		return fmt.Errorf(`Unexpected type: "%s"`, geoJSON.Type)
+	}
+	if len(geoJSON.Coordinates) < 2 {
+		return errors.New("Expected a coordinates array with two or more values")
+	}
+
+	first := geoJSON.Coordinates[0]
+	dimensions := len(first)
+	if dimensions < 2 {
+		return fmt.Errorf("Unexpected length %d for first point", dimensions)
+	}
+
+	coordinates := make([]float64, len(geoJSON.Coordinates)*dimensions)
+	for i := 0; i < len(geoJSON.Coordinates); i++ {
+		coord := geoJSON.Coordinates[i]
+		if len(coord) != dimensions {
+			return fmt.Errorf("Unexpected point length for position %d", i)
+		}
+		for j := 0; j < dimensions; j++ {
+			coordinates[i*dimensions+j] = coord[j]
+		}
+	}
+
+	line.Coordinates = coordinates
+	line.Extra = dimensions - 2
+	return nil
 }

--- a/linestring_test.go
+++ b/linestring_test.go
@@ -36,4 +36,79 @@ var _ = Describe("LineString", func() {
 
 	})
 
+	Describe("json.Unmarshal", func() {
+
+		It("Decodes GeoJSON linestrings", func() {
+			line := &LineString{}
+
+			err := json.Unmarshal([]byte(`{
+				"type": "LineString",
+				"coordinates": [[-115, 45], [115, 45]]
+			}`), line)
+
+			Ω(err).ShouldNot(HaveOccurred())
+
+			Ω(line.Coordinates).Should(Equal([]float64{-115, 45, 115, 45}))
+			Ω(line.Extra).Should(Equal(0))
+		})
+
+		It("Preserves extra dimensions", func() {
+			line := &LineString{}
+
+			err := json.Unmarshal([]byte(`{
+				"type": "LineString",
+				"coordinates": [[-115, 45, 1.234], [115, 45, 5.678]]
+			}`), line)
+
+			Ω(err).ShouldNot(HaveOccurred())
+
+			Ω(line.Coordinates).Should(Equal([]float64{-115, 45, 1.234, 115, 45, 5.678}))
+			Ω(line.Extra).Should(Equal(1))
+		})
+
+		It("Fails for invalid GeoJSON (bad type)", func() {
+			line := &LineString{}
+
+			err := json.Unmarshal([]byte(`{
+				"type": "Bogus",
+				"coordinates": [[-115, 45], [115, 45]]
+			}`), line)
+
+			Ω(err).Should(MatchError(`Unexpected type: "Bogus"`))
+		})
+
+		It("Fails for invalid GeoJSON (missing coordinates)", func() {
+			line := &LineString{}
+
+			err := json.Unmarshal([]byte(`{
+				"type": "LineString"
+			}`), line)
+
+			Ω(err).Should(MatchError("Expected a coordinates array with two or more values"))
+		})
+
+		It("Fails for invalid GeoJSON (not enough coordinates)", func() {
+			line := &LineString{}
+
+			err := json.Unmarshal([]byte(`{
+				"type": "LineString",
+				"coordinates": [[1, 2]]
+			}`), line)
+
+			Ω(err).Should(MatchError("Expected a coordinates array with two or more values"))
+		})
+
+		It("Fails for invalid GeoJSON (inconsistent coordinate dimensions)", func() {
+			line := &LineString{}
+
+			err := json.Unmarshal([]byte(`{
+				"type": "LineString",
+				"coordinates": [[1, 2], [3, 4, 5]]
+			}`), line)
+
+			Ω(err).Should(MatchError("Unexpected point length for position 1"))
+		})
+
+	})
+
 })


### PR DESCRIPTION
This adds support for decoding GeoJSON LineStrings with `json.Unmarshal(data, line)`.
